### PR TITLE
altera appSetting 'UriCorreios'

### DIFF
--- a/AddressApi.Base/AddressApi.Base.csproj
+++ b/AddressApi.Base/AddressApi.Base.csproj
@@ -11,6 +11,10 @@
     <AssemblyName>AddressApi.Base</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/AddressApi.Correios.Tests/App.config
+++ b/AddressApi.Correios.Tests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="UriCorreios" value="http://m.correios.com.br/movel/buscaCepConfirma.do"/>
+    <add key="UriCorreios" value="http://m.correios.com.br/movel/buscaCepConfirma.do?cepEntrada={0}%26tipoCep=%26cepTemp%26metodo=buscarCep" />
   </appSettings>
 </configuration>

--- a/AddressApi.Correios/AddressApi.Correios.csproj
+++ b/AddressApi.Correios/AddressApi.Correios.csproj
@@ -13,6 +13,10 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/AddressApi.Correios/CorreiosMobileCrawler.cs
+++ b/AddressApi.Correios/CorreiosMobileCrawler.cs
@@ -1,9 +1,10 @@
-﻿using System.Configuration;
+﻿using AddressApi.Base;
+using CsQuery;
+using System;
+using System.Configuration;
 using System.IO;
 using System.Net;
 using System.Text;
-using AddressApi.Base;
-using CsQuery;
 
 namespace AddressApi.Correios
 {
@@ -16,16 +17,10 @@ namespace AddressApi.Correios
         public CorreiosMobileCrawler(string zipCode)
         {
             _zipCode = zipCode;
-            _request = WebRequest.Create(ConfigurationManager.AppSettings["UriCorreios"]);
+            _request = WebRequest.Create(string.Format(Uri.UnescapeDataString(ConfigurationManager.AppSettings["UriCorreios"]), zipCode));
             _request.ContentType = "application/x-www-form-urlencoded";
             _request.Headers.Set(HttpRequestHeader.ContentEncoding, "ISO-8859-1");
             _request.Method = "POST";
-            var requestParams = Encoding.ASCII.GetBytes(string.Format("cepEntrada={0}&tipoCep=&cepTemp&metodo=buscarCep", zipCode));
-            _request.ContentLength = requestParams.Length;
-
-            var requestStream = _request.GetRequestStream();
-            requestStream.Write(requestParams, 0, requestParams.Length);
-            requestStream.Close();
         }
 
         private string GetPageContent()

--- a/AddressApi.RestApi/Web.config
+++ b/AddressApi.RestApi/Web.config
@@ -17,7 +17,7 @@
     <add key="PreserveLoginUrl" value="true" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="UriCorreios" value="http://m.correios.com.br/movel/buscaCepConfirma.do" />
+    <add key="UriCorreios" value="http://m.correios.com.br/movel/buscaCepConfirma.do?cepEntrada={0}%26tipoCep=%26cepTemp%26metodo=buscarCep" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5" />

--- a/AddressApi.sln
+++ b/AddressApi.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AddressApi.Base", "AddressApi.Base\AddressApi.Base.csproj", "{EC149A10-26BE-43A8-9445-5F9A2E7EF997}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AddressApi.Base.Tests", "AddressApi.Base.Tests\AddressApi.Base.Tests.csproj", "{FBC472F0-56F5-486D-A688-F8DD6F818367}"
@@ -19,6 +21,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{B473EB
 	EndProjectSection
 EndProject
 Global
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = 51b6c32a-a4f4-4300-b7f6-13847d2bb545
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
- altera appSetting 'UriCorreios' possibilitando que a url completa seja configurada no web.config sem que seja necessário recompilar a aplicação caso a url dos correios mude.
  - Ex.: http://m.correios.com.br/movel/buscaCepConfirma.do?cepEntrada={0}%26tipoCep=%26cepTemp%26metodo=buscarCep
- altera arquivo sln permitindo editar a solução também com VS2013 (mantém compatibilidade com VS2012)
